### PR TITLE
Update documentation regarding custom scalars & optional/nullable types

### DIFF
--- a/website/versioned_docs/version-6.x.x/schema-generator/schema-generator-getting-started.mdx
+++ b/website/versioned_docs/version-6.x.x/schema-generator/schema-generator-getting-started.mdx
@@ -142,3 +142,9 @@ val customDef = TopLevelObject(query, Query::class)
 
 toSchema(config, listOf(customDef))
 ```
+
+:::note
+Custom scalars combined with optional/nullable types on constructors are not supported in 6.x.x. Fixing in https://github.com/ExpediaGroup/graphql-kotlin/issues/1549.
+
+More info: https://github.com/ExpediaGroup/graphql-kotlin/issues/1564.
+:::


### PR DESCRIPTION
### :pencil: Description
As part of an issue created within graphql-kotlin, we need to update the graphql-kotlin v6.x.x documentation stating that the custom scalars combined with optional/nullable types on constructors are not supported.

As a comment, this issue will get addressed once the update to Kotlin v1.7 is done.

### :link: Related Issues
https://github.com/ExpediaGroup/graphql-kotlin/issues/1564


